### PR TITLE
Send information to indicate when video processor is queueing & Allow tasks to not get blocked when they are finishing up / doing something quick

### DIFF
--- a/Docs/articles/guides/processing-pipelines.md
+++ b/Docs/articles/guides/processing-pipelines.md
@@ -22,12 +22,12 @@ var added = await txn.AddAsync(reportStream, ".pdf", leaveOpen: true, FileProces
 
 ## Building a Pipeline
 
-Construct a pipeline from one or more processors. Processors run in order, each receiving the previous step's output, which is what lets you compose two transformations into a single step. A common case is producing a compact JPEG thumbnail of a video: <xref:FulcrumFS.Videos.VideoThumbnailProcessor> extracts a full-resolution PNG poster frame, then <xref:FulcrumFS.Images.ImageProcessor> resizes that frame and converts it to JPEG.
+Construct a pipeline from one or more processors. Processors run in order, each receiving the previous step's output, which is what lets you compose two transformations into a single step. A common case is producing a compact JPEG thumbnail of a video: <xref:FulcrumFS.Videos.VideoFrameExtractionProcessor> extracts a full-resolution PNG poster frame, then <xref:FulcrumFS.Images.ImageProcessor> resizes that frame and converts it to JPEG.
 
 ```csharp
 // Extract a poster frame, then resize/convert it to a 256x256 JPEG thumbnail.
 var pipeline = new FileProcessingPipeline(
-    new VideoThumbnailProcessor(VideoThumbnailProcessingOptions.Standard),
+    new VideoFrameExtractionProcessor(VideoFrameExtractionProcessingOptions.Standard),
     new ImageProcessor(new ImageProcessingOptions {
         Formats = [new ImageFormatMapping(ImageFormat.Png, ImageFormat.Jpeg)],
         Resize = new ImageResizeOptions(ImageResizeMode.FitDown, 256, 256),

--- a/Docs/articles/guides/video-processing.md
+++ b/Docs/articles/guides/video-processing.md
@@ -6,7 +6,7 @@ The `Singulink.FulcrumFS.Videos` package adds video processing built on FFmpeg a
 
 ### Where it fits
 
-<xref:FulcrumFS.Videos.VideoProcessor> and <xref:FulcrumFS.Videos.VideoThumbnailProcessor> are both <xref:FulcrumFS.FileProcessor> types, so they compose into pipelines and variants. Add `using FulcrumFS.Videos;` alongside `using FulcrumFS;`.
+<xref:FulcrumFS.Videos.VideoProcessor> and <xref:FulcrumFS.Videos.VideoFrameExtractionProcessor> are both <xref:FulcrumFS.FileProcessor> types, so they compose into pipelines and variants. Add `using FulcrumFS.Videos;` alongside `using FulcrumFS;`.
 
 > [!NOTE]
 > Video transcoding is CPU-intensive, often taking many seconds (or minutes) per file. A synchronous upload handler that transcodes during the request will tie up a worker thread for the duration. For large videos, consider queueing the add to a background service so the upload endpoint returns quickly.
@@ -33,7 +33,7 @@ There are also additional configuration options that can be used:
 - And `ProcessPriorityClass` can be used to set the priority class for `ffmpeg`/`ffprobe` processes, to ensure that other tasks have higher priority for example (by setting the `ffmpeg`/`ffprobe` ones to `BelowNormal`) - see `Process.ProcessPriorityClass` for more information.
 
 > [!IMPORTANT]
-> Constructing a <xref:FulcrumFS.Videos.VideoProcessor> or <xref:FulcrumFS.Videos.VideoThumbnailProcessor> before configuring the executables throws. The constructor also verifies that the configured FFmpeg build supports the codecs, demuxers, and encoders the options require, and throws <xref:System.NotSupportedException> if something is missing, so a misconfigured deployment fails fast at startup rather than on the first upload.
+> Constructing a <xref:FulcrumFS.Videos.VideoProcessor> or <xref:FulcrumFS.Videos.VideoFrameExtractionProcessor> before configuring the executables throws. The constructor also verifies that the configured FFmpeg build supports the codecs, demuxers, and encoders the options require, and throws <xref:System.NotSupportedException> if something is missing, so a misconfigured deployment fails fast at startup rather than on the first upload.
 
 ## The Video Processor
 
@@ -59,14 +59,14 @@ var options = VideoProcessingOptions.StandardizedH264AACMP4 with {
 
 ## Extracting a Thumbnail
 
-<xref:FulcrumFS.Videos.VideoThumbnailProcessor> extracts a poster frame as a PNG, which is what a gallery view needs so the user can see what each video looks like without playing it. It performs no validation itself, so when validation matters, run a <xref:FulcrumFS.Videos.VideoProcessor> first and chain the thumbnail step after it. Configure it with <xref:FulcrumFS.Videos.VideoThumbnailProcessingOptions>, and use the predefined <xref:FulcrumFS.Videos.VideoThumbnailProcessingOptions.Standard> for typical needs.
+<xref:FulcrumFS.Videos.VideoFrameExtractionProcessor> extracts a poster frame as a PNG, which is what a gallery view needs so the user can see what each video looks like without playing it. It performs no validation itself, so when validation matters, run a <xref:FulcrumFS.Videos.VideoProcessor> first and chain the thumbnail step after it. Configure it with <xref:FulcrumFS.Videos.VideoThumbnailProcessingOptions>, and use the predefined <xref:FulcrumFS.Videos.VideoThumbnailProcessingOptions.Standard> for typical needs.
 
 A full-resolution PNG poster frame is usually larger than a gallery tile needs, so a real thumbnail variant chains the extractor with an <xref:FulcrumFS.Images.ImageProcessor> that resizes it down and converts to JPEG:
 
 ```csharp
 // Resize the extracted poster frame down to a 256x256 JPEG.
 var thumbnailPipeline = new FileProcessingPipeline(
-    new VideoThumbnailProcessor(VideoThumbnailProcessingOptions.Standard),
+    new VideoFrameExtractionProcessor(VideoFrameExtractionProcessingOptions.Standard),
     new ImageProcessor(new ImageProcessingOptions {
         Formats = [new ImageFormatMapping(ImageFormat.Png, ImageFormat.Jpeg)],
         Resize = new ImageResizeOptions(ImageResizeMode.FitDown, 256, 256),

--- a/README.md
+++ b/README.md
@@ -52,17 +52,17 @@ Main library that enables transactional file storage and processing, providing a
 
 **Features**:
 
-✔️ **Commit-then-cleanup coordination** with transactional databases - orphaned files from failed commits are reclaimed automatically  
-✔️ **No distributed transactions required** - avoids 2PC coordinator overhead and indeterminate post-crash database states that block reopening  
-✔️ Validate, pre-process, and post-process files during storage and retrieval  
-✔️ Generate and manage file variants (e.g. alternate formats, resolutions, thumbnails)  
-✔️ Operates reliably on any file system, including local disks, NAS, and network file systems  
-✔️ Recovers gracefully from crashes, power failures and disconnected storage volumes  
-✔️ Scales to **millions of files** per repository while maintaining good file system performance characteristics  
-✔️ Provides **direct `FileStream` access** for efficient, low-overhead file I/O  
-✔️ Stored files remain browsable in standard file managers (e.g. File Explorer, Finder)  
-✔️ Fully compatible with file system features like encryption and compression  
-✔️ Designed to work seamlessly with existing backup, redundancy, replication, and storage tools  
+✔️ **Commit-then-cleanup coordination** with transactional databases - orphaned files from failed commits are reclaimed automatically
+✔️ **No distributed transactions required** - avoids 2PC coordinator overhead and indeterminate post-crash database states that block reopening
+✔️ Validate, pre-process, and post-process files during storage and retrieval
+✔️ Generate and manage file variants (e.g. alternate formats, resolutions, thumbnails)
+✔️ Operates reliably on any file system, including local disks, NAS, and network file systems
+✔️ Recovers gracefully from crashes, power failures and disconnected storage volumes
+✔️ Scales to **millions of files** per repository while maintaining good file system performance characteristics
+✔️ Provides **direct `FileStream` access** for efficient, low-overhead file I/O
+✔️ Stored files remain browsable in standard file managers (e.g. File Explorer, Finder)
+✔️ Fully compatible with file system features like encryption and compression
+✔️ Designed to work seamlessly with existing backup, redundancy, replication, and storage tools
 
 #### FulcrumFS.Core
 
@@ -125,7 +125,7 @@ var imagePipeline = new ImageProcessor(new ImageProcessingOptions {
 // the video frame extractor into the shared thumbnail processor.
 var videoPipeline = new VideoProcessor(VideoProcessingOptions.StandardizedH264AACMP4)
     .WithVariant("thumbnail", new FileProcessingPipeline(
-        new VideoThumbnailProcessor(VideoThumbnailProcessingOptions.Standard),
+        new VideoFrameExtractionProcessor(VideoFrameExtractionProcessingOptions.Standard),
         thumbnailProcessor,
     ));
 

--- a/Source/FulcrumFS.Videos/FFmpegUtils.cs
+++ b/Source/FulcrumFS.Videos/FFmpegUtils.cs
@@ -487,7 +487,7 @@ internal static class FFmpegUtils
         FFmpegCommand command,
         Func<double, ValueTask>? progressCallback,
         IAbsoluteFilePath? progressFilePath,
-        Func<bool, ValueTask>? queueingCallback = null, // true means queued, false means dequeued - not called if never queued.
+        Func<bool, ValueTask>? queueingCallback = null, // true means queued, false means dequeued - may be partially or never called at all.
         ProcessLifetime lifetime = ProcessLifetime.LongLived,
         CancellationToken cancellationToken = default)
     {
@@ -518,7 +518,7 @@ internal static class FFmpegUtils
         Func<double, ValueTask>? progressCallback,
         IAbsoluteFilePath? progressFilePath,
         bool ensureAllProgressRead, // Ensures that all progress is read if at least one progress callback is invoked.
-        Func<bool, ValueTask>? queueingCallback = null, // true means queued, false means dequeued - not called if never queued.
+        Func<bool, ValueTask>? queueingCallback = null, // true means queued, false means dequeued - may be partially or never called at all.
         ProcessLifetime lifetime = ProcessLifetime.LongLived,
         CancellationToken cancellationToken = default)
     {

--- a/Source/FulcrumFS.Videos/FFmpegUtils.cs
+++ b/Source/FulcrumFS.Videos/FFmpegUtils.cs
@@ -488,6 +488,7 @@ internal static class FFmpegUtils
         Func<double, ValueTask>? progressCallback,
         IAbsoluteFilePath? progressFilePath,
         Func<bool, ValueTask>? queueingCallback = null, // true means queued, false means dequeued - not called if never queued.
+        ProcessLifetime lifetime = ProcessLifetime.LongLived,
         CancellationToken cancellationToken = default)
     {
         // Validate progress callback and progress temp file path args:
@@ -507,6 +508,7 @@ internal static class FFmpegUtils
             progressFilePath,
             ensureAllProgressRead: false,
             queueingCallback: queueingCallback,
+            lifetime: lifetime,
             cancellationToken: cancellationToken)
         .ConfigureAwait(false);
     }
@@ -517,6 +519,7 @@ internal static class FFmpegUtils
         IAbsoluteFilePath? progressFilePath,
         bool ensureAllProgressRead, // Ensures that all progress is read if at least one progress callback is invoked.
         Func<bool, ValueTask>? queueingCallback = null, // true means queued, false means dequeued - not called if never queued.
+        ProcessLifetime lifetime = ProcessLifetime.LongLived,
         CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
@@ -629,6 +632,7 @@ internal static class FFmpegUtils
                     VideoProcessor.FFmpegExePath,
                     args,
                     standardOutputWriter: null,
+                    lifetime: lifetime,
                     queueingCallback: queueingCallback,
                     cancellationToken: cancellationToken)
                     .ConfigureAwait(false);

--- a/Source/FulcrumFS.Videos/FFmpegUtils.cs
+++ b/Source/FulcrumFS.Videos/FFmpegUtils.cs
@@ -487,7 +487,7 @@ internal static class FFmpegUtils
         FFmpegCommand command,
         Func<double, ValueTask>? progressCallback,
         IAbsoluteFilePath? progressFilePath,
-        Func<bool, ValueTask>? queueingCallback = null, // true means queued, false means dequeued - may be partially or never called at all.
+        Func<bool, ValueTask>? queueingCallback = null,
         ProcessLifetime lifetime = ProcessLifetime.LongLived,
         CancellationToken cancellationToken = default)
     {
@@ -518,7 +518,7 @@ internal static class FFmpegUtils
         Func<double, ValueTask>? progressCallback,
         IAbsoluteFilePath? progressFilePath,
         bool ensureAllProgressRead, // Ensures that all progress is read if at least one progress callback is invoked.
-        Func<bool, ValueTask>? queueingCallback = null, // true means queued, false means dequeued - may be partially or never called at all.
+        Func<bool, ValueTask>? queueingCallback = null,
         ProcessLifetime lifetime = ProcessLifetime.LongLived,
         CancellationToken cancellationToken = default)
     {

--- a/Source/FulcrumFS.Videos/FFmpegUtils.cs
+++ b/Source/FulcrumFS.Videos/FFmpegUtils.cs
@@ -487,6 +487,7 @@ internal static class FFmpegUtils
         FFmpegCommand command,
         Func<double, ValueTask>? progressCallback,
         IAbsoluteFilePath? progressFilePath,
+        Func<bool, ValueTask>? queueingCallback = null, // true means queued, false means dequeued - not called if never queued.
         CancellationToken cancellationToken = default)
     {
         // Validate progress callback and progress temp file path args:
@@ -505,6 +506,7 @@ internal static class FFmpegUtils
             progressCallback,
             progressFilePath,
             ensureAllProgressRead: false,
+            queueingCallback: queueingCallback,
             cancellationToken: cancellationToken)
         .ConfigureAwait(false);
     }
@@ -514,6 +516,7 @@ internal static class FFmpegUtils
         Func<double, ValueTask>? progressCallback,
         IAbsoluteFilePath? progressFilePath,
         bool ensureAllProgressRead, // Ensures that all progress is read if at least one progress callback is invoked.
+        Func<bool, ValueTask>? queueingCallback = null, // true means queued, false means dequeued - not called if never queued.
         CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
@@ -626,6 +629,7 @@ internal static class FFmpegUtils
                     VideoProcessor.FFmpegExePath,
                     args,
                     standardOutputWriter: null,
+                    queueingCallback: queueingCallback,
                     cancellationToken: cancellationToken)
                     .ConfigureAwait(false);
             }

--- a/Source/FulcrumFS.Videos/FFprobeUtils.cs
+++ b/Source/FulcrumFS.Videos/FFprobeUtils.cs
@@ -157,7 +157,7 @@ internal static class FFprobeUtils
         string json = await ProcessUtils.RunProcessToStringWithErrorHandlingAsync(
             VideoProcessor.FFprobeExePath,
             ["-show_format", "-show_streams", "-print_format", "json", "-v", "error", "-hide_banner", "-i", filePath.PathExport],
-            isShortLived: true,
+            lifetime: ProcessLifetime.ShortLived,
             cancellationToken: cancellationToken).ConfigureAwait(false);
 
         cancellationToken.ThrowIfCancellationRequested();
@@ -314,7 +314,7 @@ internal static class FFprobeUtils
         string result = ProcessUtils.RunProcessToStringWithErrorHandlingAsync(
             VideoProcessor.FFprobeExePath,
             [command, "-hide_banner", "-v", "error"],
-            isShortLived: true,
+            lifetime: ProcessLifetime.ShortLived,
             cancellationToken: cancellationToken,
             runAsynchronously: false).GetAwaiter().GetResult();
 

--- a/Source/FulcrumFS.Videos/ProcessLifetime.cs
+++ b/Source/FulcrumFS.Videos/ProcessLifetime.cs
@@ -1,0 +1,30 @@
+namespace FulcrumFS.Videos;
+
+/// <summary>
+/// Identifies the expected lifetime / resource consumption of an external process, which determines which process slot tier/s it is allowed to run in.
+/// </summary>
+internal enum ProcessLifetime
+{
+    /// <summary>
+    /// A long-lived process (e.g. a full video processing run). Only runs in the main process slots.
+    /// </summary>
+    LongLived,
+
+    /// <summary>
+    /// A cheap long-lived process (e.g. smallest-result detection, stream recombination passes, or compatibility check). Has its own extra slot in addition to
+    /// the main process slots, so it can still run even if unrelated long-lived jobs have taken all the main slots.
+    /// </summary>
+    CheapLongLived,
+
+    /// <summary>
+    /// A medium-lived process (e.g. a video frame / thumbnail extraction). Has its own extra slot in addition to the main / cheap long-lived process slots, so
+    /// one can always run and remain relatively quick without having to queue behind long-lived processes.
+    /// </summary>
+    MediumLived,
+
+    /// <summary>
+    /// A short-lived process (e.g. an ffprobe run). Has its own extra slot in addition to the main / cheap long-lived / medium process slots, so it can always
+    /// start and finish fast.
+    /// </summary>
+    ShortLived,
+}

--- a/Source/FulcrumFS.Videos/ProcessUtils.cs
+++ b/Source/FulcrumFS.Videos/ProcessUtils.cs
@@ -52,6 +52,8 @@ internal static class ProcessUtils
 
         // We always want to notify when we stop queueing; use a try/finally for that.
         SemaphoreSlim? semaphore = null;
+        bool entered = true;
+
         try
         {
             // Otherwise, wait asynchronously for availability on the process's own tier semaphore.
@@ -65,8 +67,12 @@ internal static class ProcessUtils
                 _ => processesSemaphore,
             };
 
-            if (runAsynchronously) await semaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
-            else semaphore.Wait(cancellationToken);
+            if (runAsynchronously)
+                await semaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
+            else
+                semaphore.Wait(cancellationToken);
+
+            entered = true;
 
             // If we entered an extra tier semaphore but a slot is available in a longer tier (main first, then cheap long, then medium over short), switch to
             // that one.
@@ -92,6 +98,7 @@ internal static class ProcessUtils
             catch
             {
                 semaphore.Release();
+                entered = false;
                 throw;
             }
 
@@ -111,7 +118,10 @@ internal static class ProcessUtils
                 // Ensure we don't leave the semaphore acquired if the queueing callback throws an exception.
                 // Note: we shouldn't ever get here anyway, so also include a debug assertion; this is just for safety in Release mode really.
                 Debug.Fail("Queueing callback threw an exception.");
-                semaphore?.Release();
+
+                if (entered)
+                    semaphore?.Release();
+
                 throw;
             }
         }

--- a/Source/FulcrumFS.Videos/ProcessUtils.cs
+++ b/Source/FulcrumFS.Videos/ProcessUtils.cs
@@ -50,55 +50,61 @@ internal static class ProcessUtils
         if (queueingCallback is not null)
             await queueingCallback(true).ConfigureAwait(false);
 
-        // Otherwise, wait asynchronously for availability on the process's own tier semaphore.
-        // Note: short/medium-lived processes have their own semaphores to avoid being blocked by long-running ones, but if the process is not actually
-        // short/medium-lived, the queue to run such processes quickly may get starved as there's only one slot available per tier for quick running.
-        var semaphore = lifetime switch
-        {
-            ProcessLifetime.ShortLived => _shortLivedProcessesSemaphore,
-            ProcessLifetime.MediumLived => _mediumLivedProcessesSemaphore,
-            ProcessLifetime.CheapLongLived => _cheapLongLivedProcessesSemaphore,
-            _ => processesSemaphore,
-        };
-
-        if (runAsynchronously)
-            await semaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
-        else
-            semaphore.Wait(cancellationToken);
-
-        // If we entered an extra tier semaphore but a slot is available in a longer tier (main first, then cheap long, then medium over short), switch to
-        // that one.
+        // We always want to report as dequeued when we exit the method, even if throwing.
         try
         {
-            if (semaphore != processesSemaphore && processesSemaphore.Wait(0, cancellationToken: default))
+            // Otherwise, wait asynchronously for availability on the process's own tier semaphore.
+            // Note: short/medium-lived processes have their own semaphores to avoid being blocked by long-running ones, but if the process is not actually
+            // short/medium-lived, the queue to run such processes quickly may get starved as there's only one slot available per tier for quick running.
+            var semaphore = lifetime switch
+            {
+                ProcessLifetime.ShortLived => _shortLivedProcessesSemaphore,
+                ProcessLifetime.MediumLived => _mediumLivedProcessesSemaphore,
+                ProcessLifetime.CheapLongLived => _cheapLongLivedProcessesSemaphore,
+                _ => processesSemaphore,
+            };
+
+            if (runAsynchronously)
+                await semaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
+            else
+                semaphore.Wait(cancellationToken);
+
+            // If we entered an extra tier semaphore but a slot is available in a longer tier (main first, then cheap long, then medium over short), switch to
+            // that one.
+            try
+            {
+                if (semaphore != processesSemaphore && processesSemaphore.Wait(0, cancellationToken: default))
+                {
+                    semaphore.Release();
+                    semaphore = processesSemaphore;
+                }
+                else if ((semaphore == _mediumLivedProcessesSemaphore || semaphore == _shortLivedProcessesSemaphore) &&
+                    _cheapLongLivedProcessesSemaphore.Wait(0, cancellationToken: default))
+                {
+                    semaphore.Release();
+                    semaphore = _cheapLongLivedProcessesSemaphore;
+                }
+                else if (semaphore == _shortLivedProcessesSemaphore && _mediumLivedProcessesSemaphore.Wait(0, cancellationToken: default))
+                {
+                    semaphore.Release();
+                    semaphore = _mediumLivedProcessesSemaphore;
+                }
+            }
+            catch
             {
                 semaphore.Release();
-                semaphore = processesSemaphore;
+                throw;
             }
-            else if ((semaphore == _mediumLivedProcessesSemaphore || semaphore == _shortLivedProcessesSemaphore) &&
-                _cheapLongLivedProcessesSemaphore.Wait(0, cancellationToken: default))
-            {
-                semaphore.Release();
-                semaphore = _cheapLongLivedProcessesSemaphore;
-            }
-            else if (semaphore == _shortLivedProcessesSemaphore && _mediumLivedProcessesSemaphore.Wait(0, cancellationToken: default))
-            {
-                semaphore.Release();
-                semaphore = _mediumLivedProcessesSemaphore;
-            }
+
+            // Return the semaphore we acquired.
+            return semaphore;
         }
-        catch
+        finally
         {
-            semaphore.Release();
-            throw;
+            // We successfully acquired a semaphore slot, so notify that we are dequeued if applicable.
+            if (queueingCallback is not null)
+                await queueingCallback(false).ConfigureAwait(false);
         }
-
-        // We successfully acquired a semaphore slot, so notify that we are dequeued if applicable.
-        if (queueingCallback is not null)
-            await queueingCallback(false).ConfigureAwait(false);
-
-        // Return the semaphore we acquired.
-        return semaphore;
     }
 
     private static void KillProcessSafely(Process process)
@@ -260,7 +266,7 @@ internal static class ProcessUtils
         }
     }
 
-    // Note about queueingCallback: true means queued, false means dequeued - not called when never queued, and not called for dequeue on exception.
+    // Note about queueingCallback: true means queued, false means dequeued - not called when never queued, and always called with false, even when throwing.
 
     public static async ValueTask<(string Output, string Error, int ReturnCode)> RunProcessToStringAsync(
         IAbsoluteFilePath fileName,

--- a/Source/FulcrumFS.Videos/ProcessUtils.cs
+++ b/Source/FulcrumFS.Videos/ProcessUtils.cs
@@ -16,7 +16,11 @@ internal static class ProcessUtils
     private static SemaphoreSlim ProcessesSemaphore
         => _processesSemaphore ??= new SemaphoreSlim(VideoProcessor.MaxConcurrentProcesses, VideoProcessor.MaxConcurrentProcesses);
 
-    private static async ValueTask<SemaphoreSlim> JoinProcessSemaphoreAsync(bool isShortLived, bool runAsynchronously, CancellationToken cancellationToken)
+    private static async ValueTask<SemaphoreSlim> JoinProcessSemaphoreAsync(
+        bool isShortLived,
+        bool runAsynchronously,
+        Func<bool, ValueTask>? queueingCallback, // true means queued, false means dequeued - not called if never queued.
+        CancellationToken cancellationToken)
     {
         // Try to enter the main semaphore without waiting first to avoid unnecessary context switches.
         // Note: short-lived can still use the main semaphore if available, we are just trying to prioritize them running since they're fast to allow tasks to
@@ -27,30 +31,44 @@ internal static class ProcessUtils
         // If the process is short-lived, try to enter its extra semaphore without waiting.
         if (isShortLived && _shortLivedProcessesSemaphore.Wait(0, cancellationToken: default)) return _shortLivedProcessesSemaphore;
 
-        // Otherwise, wait asynchronously for availability.
-        // Note: short-lived processes have their own semaphore to avoid being blocked by long-running ones, but if the process is not actually short-lived,
-        // the queue to run short-lived processes quickly may get starved as there's only one slot available for quick running.
-        var semaphore = isShortLived ? _shortLivedProcessesSemaphore : processesSemaphore;
-        if (runAsynchronously) await semaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
-        else semaphore.Wait(cancellationToken);
+        // Notify that we could not get a process slot immediately and have to start queueing.
+        if (queueingCallback is not null)
+            await queueingCallback(true).ConfigureAwait(false);
 
-        // If we entered the short-lived semaphore but a slot is available in the main semaphore, switch to that one.
+        // We always want to notify when we stop queueing; use a try/finally for that.
         try
         {
-            if (semaphore == _shortLivedProcessesSemaphore && processesSemaphore.Wait(0, cancellationToken: default))
-            {
-                _shortLivedProcessesSemaphore.Release();
-                semaphore = processesSemaphore;
-            }
-        }
-        catch
-        {
-            semaphore.Release();
-            throw;
-        }
+            // Otherwise, wait asynchronously for availability.
+            // Note: short-lived processes have their own semaphore to avoid being blocked by long-running ones, but if the process is not actually short-lived,
+            // the queue to run short-lived processes quickly may get starved as there's only one slot available for quick running.
+            var semaphore = isShortLived ? _shortLivedProcessesSemaphore : processesSemaphore;
+            if (runAsynchronously) await semaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
+            else semaphore.Wait(cancellationToken);
 
-        // Return the semaphore we acquired.
-        return semaphore;
+            // If we entered the short-lived semaphore but a slot is available in the main semaphore, switch to that one.
+            try
+            {
+                if (semaphore == _shortLivedProcessesSemaphore && processesSemaphore.Wait(0, cancellationToken: default))
+                {
+                    _shortLivedProcessesSemaphore.Release();
+                    semaphore = processesSemaphore;
+                }
+            }
+            catch
+            {
+                semaphore.Release();
+                throw;
+            }
+
+            // Return the semaphore we acquired.
+            return semaphore;
+        }
+        finally
+        {
+            // Notify that we finished queueing and got a process slot.
+            if (queueingCallback is not null)
+                await queueingCallback(false).ConfigureAwait(false);
+        }
     }
 
     private static void KillProcessSafely(Process process)
@@ -103,6 +121,7 @@ internal static class ProcessUtils
         bool isShortLived,
         bool redirectOutputContinually,
         bool runAsynchronously,
+        Func<bool, ValueTask>? queueingCallback, // true means queued, false means dequeued - not called if never queued.
         CancellationToken cancellationToken)
     {
         List<Task>? redirectTasks = null;
@@ -111,7 +130,7 @@ internal static class ProcessUtils
 
         try
         {
-            var semaphore = await JoinProcessSemaphoreAsync(isShortLived, runAsynchronously, cancellationToken).ConfigureAwait(false);
+            var semaphore = await JoinProcessSemaphoreAsync(isShortLived, runAsynchronously, queueingCallback, cancellationToken).ConfigureAwait(false);
             try
             {
                 process = new Process
@@ -215,6 +234,7 @@ internal static class ProcessUtils
         IAbsoluteFilePath fileName,
         IEnumerable<string> arguments,
         bool isShortLived = false,
+        Func<bool, ValueTask>? queueingCallback = null, // true means queued, false means dequeued - not called if never queued.
         CancellationToken cancellationToken = default,
         bool runAsynchronously = true)
     {
@@ -229,6 +249,7 @@ internal static class ProcessUtils
             isShortLived,
             redirectOutputContinually: false,
             runAsynchronously,
+            queueingCallback,
             cancellationToken).ConfigureAwait(false);
 
         return (standardOutputWriter.ToString(), standardErrorWriter.ToString(), returnCode);
@@ -238,6 +259,7 @@ internal static class ProcessUtils
         IAbsoluteFilePath fileName,
         IEnumerable<string> arguments,
         bool isShortLived = false,
+        Func<bool, ValueTask>? queueingCallback = null, // true means queued, false means dequeued - not called if never queued.
         CancellationToken cancellationToken = default,
         bool runAsynchronously = true)
     {
@@ -252,6 +274,7 @@ internal static class ProcessUtils
             isShortLived,
             redirectOutputContinually: false,
             runAsynchronously,
+            queueingCallback,
             cancellationToken).ConfigureAwait(false);
 
         if (returnCode != 0)
@@ -287,6 +310,7 @@ internal static class ProcessUtils
         TextWriter? standardOutputWriter,
         bool isShortLived = false,
         bool runAsynchronously = true,
+        Func<bool, ValueTask>? queueingCallback = null, // true means queued, false means dequeued - not called if never queued.
         CancellationToken cancellationToken = default)
     {
         using StringWriter standardErrorWriter = new();
@@ -299,6 +323,7 @@ internal static class ProcessUtils
             isShortLived,
             redirectOutputContinually: true,
             runAsynchronously,
+            queueingCallback,
             cancellationToken).ConfigureAwait(false);
 
         if (returnCode != 0)

--- a/Source/FulcrumFS.Videos/ProcessUtils.cs
+++ b/Source/FulcrumFS.Videos/ProcessUtils.cs
@@ -21,7 +21,7 @@ internal static class ProcessUtils
     private static async ValueTask<SemaphoreSlim> JoinProcessSemaphoreAsync(
         ProcessLifetime lifetime,
         bool runAsynchronously,
-        Func<bool, ValueTask>? queueingCallback, // true means queued, false means dequeued - may be partially or never called at all.
+        Func<bool, ValueTask>? queueingCallback,
         CancellationToken cancellationToken)
     {
         // Try to enter the main semaphore without waiting first to avoid unnecessary context switches.
@@ -151,7 +151,7 @@ internal static class ProcessUtils
         ProcessLifetime lifetime,
         bool redirectOutputContinually,
         bool runAsynchronously,
-        Func<bool, ValueTask>? queueingCallback, // true means queued, false means dequeued - may be partially or never called at all.
+        Func<bool, ValueTask>? queueingCallback,
         CancellationToken cancellationToken)
     {
         List<Task>? redirectTasks = null;
@@ -260,11 +260,13 @@ internal static class ProcessUtils
         }
     }
 
+    // Note about queuingCallback: true means queued, false means dequeued - not called when never queued, and not called for dequeue on exception.
+
     public static async ValueTask<(string Output, string Error, int ReturnCode)> RunProcessToStringAsync(
         IAbsoluteFilePath fileName,
         IEnumerable<string> arguments,
         ProcessLifetime lifetime = ProcessLifetime.LongLived,
-        Func<bool, ValueTask>? queueingCallback = null, // true means queued, false means dequeued - may be partially or never called at all.
+        Func<bool, ValueTask>? queueingCallback = null,
         CancellationToken cancellationToken = default,
         bool runAsynchronously = true)
     {
@@ -289,7 +291,7 @@ internal static class ProcessUtils
         IAbsoluteFilePath fileName,
         IEnumerable<string> arguments,
         ProcessLifetime lifetime = ProcessLifetime.LongLived,
-        Func<bool, ValueTask>? queueingCallback = null, // true means queued, false means dequeued - may be partially or never called at all.
+        Func<bool, ValueTask>? queueingCallback = null,
         CancellationToken cancellationToken = default,
         bool runAsynchronously = true)
     {
@@ -340,7 +342,7 @@ internal static class ProcessUtils
         TextWriter? standardOutputWriter,
         ProcessLifetime lifetime = ProcessLifetime.LongLived,
         bool runAsynchronously = true,
-        Func<bool, ValueTask>? queueingCallback = null, // true means queued, false means dequeued - may be partially or never called at all.
+        Func<bool, ValueTask>? queueingCallback = null,
         CancellationToken cancellationToken = default)
     {
         using StringWriter standardErrorWriter = new();

--- a/Source/FulcrumFS.Videos/ProcessUtils.cs
+++ b/Source/FulcrumFS.Videos/ProcessUtils.cs
@@ -260,7 +260,7 @@ internal static class ProcessUtils
         }
     }
 
-    // Note about queuingCallback: true means queued, false means dequeued - not called when never queued, and not called for dequeue on exception.
+    // Note about queueingCallback: true means queued, false means dequeued - not called when never queued, and not called for dequeue on exception.
 
     public static async ValueTask<(string Output, string Error, int ReturnCode)> RunProcessToStringAsync(
         IAbsoluteFilePath fileName,

--- a/Source/FulcrumFS.Videos/ProcessUtils.cs
+++ b/Source/FulcrumFS.Videos/ProcessUtils.cs
@@ -51,12 +51,13 @@ internal static class ProcessUtils
             await queueingCallback(true).ConfigureAwait(false);
 
         // We always want to notify when we stop queueing; use a try/finally for that.
+        SemaphoreSlim? semaphore = null;
         try
         {
             // Otherwise, wait asynchronously for availability on the process's own tier semaphore.
             // Note: short/medium-lived processes have their own semaphores to avoid being blocked by long-running ones, but if the process is not actually
             // short/medium-lived, the queue to run such processes quickly may get starved as there's only one slot available per tier for quick running.
-            var semaphore = lifetime switch
+            semaphore = lifetime switch
             {
                 ProcessLifetime.ShortLived => _shortLivedProcessesSemaphore,
                 ProcessLifetime.MediumLived => _mediumLivedProcessesSemaphore,
@@ -100,8 +101,19 @@ internal static class ProcessUtils
         finally
         {
             // Notify that we finished queueing and got a process slot.
-            if (queueingCallback is not null)
-                await queueingCallback(false).ConfigureAwait(false);
+            try
+            {
+                if (queueingCallback is not null)
+                    await queueingCallback(false).ConfigureAwait(false);
+            }
+            catch
+            {
+                // Ensure we don't leave the semaphore acquired if the queueing callback throws an exception.
+                // Note: we shouldn't ever get here anyway, so also include a debug assertion; this is just for safety in Release mode really.
+                Debug.Fail("Queueing callback threw an exception.");
+                semaphore?.Release();
+                throw;
+            }
         }
     }
 

--- a/Source/FulcrumFS.Videos/ProcessUtils.cs
+++ b/Source/FulcrumFS.Videos/ProcessUtils.cs
@@ -12,24 +12,39 @@ namespace FulcrumFS.Videos;
 internal static class ProcessUtils
 {
     private static readonly SemaphoreSlim _shortLivedProcessesSemaphore = new(1, 1);
+    private static readonly SemaphoreSlim _mediumLivedProcessesSemaphore = new(1, 1);
+    private static readonly SemaphoreSlim _cheapLongLivedProcessesSemaphore = new(1, 1);
     private static SemaphoreSlim? _processesSemaphore;
     private static SemaphoreSlim ProcessesSemaphore
         => _processesSemaphore ??= new SemaphoreSlim(VideoProcessor.MaxConcurrentProcesses, VideoProcessor.MaxConcurrentProcesses);
 
     private static async ValueTask<SemaphoreSlim> JoinProcessSemaphoreAsync(
-        bool isShortLived,
+        ProcessLifetime lifetime,
         bool runAsynchronously,
         Func<bool, ValueTask>? queueingCallback, // true means queued, false means dequeued - not called if never queued.
         CancellationToken cancellationToken)
     {
         // Try to enter the main semaphore without waiting first to avoid unnecessary context switches.
-        // Note: short-lived can still use the main semaphore if available, we are just trying to prioritize them running since they're fast to allow tasks to
-        // continue asap.
+        // Note: short/medium-lived can still use the main semaphore if available, we are just trying to prioritize them running since they're faster to allow
+        // tasks to continue asap & not be blocked by a set of long renders for example.
+        // Note: we preferentially use more constrained semaphores always; this ensures that we don't try to get too far into too many tasks at once such that
+        // they all slow down / queue repeatedly; it tries to limit slowdown / queueing to happening fewer times overall, even if for a bit longer, and to
+        // reduce slowdown of already-running things by minimizing number of extra tasks above normal, while keeping the benefits of getting quicker things done
+        // quickly.
         var processesSemaphore = ProcessesSemaphore;
         if (processesSemaphore.Wait(0, cancellationToken: default)) return processesSemaphore;
 
-        // If the process is short-lived, try to enter its extra semaphore without waiting.
-        if (isShortLived && _shortLivedProcessesSemaphore.Wait(0, cancellationToken: default)) return _shortLivedProcessesSemaphore;
+        // If the process is not fully long-lived, try to enter the cheap long-lived extra semaphore without waiting.
+        if (lifetime is not ProcessLifetime.LongLived && _cheapLongLivedProcessesSemaphore.Wait(0, cancellationToken: default))
+            return _cheapLongLivedProcessesSemaphore;
+
+        // If the process is medium-lived or short-lived, try to enter the medium-lived extra semaphore without waiting.
+        if (lifetime is ProcessLifetime.MediumLived or ProcessLifetime.ShortLived && _mediumLivedProcessesSemaphore.Wait(0, cancellationToken: default))
+            return _mediumLivedProcessesSemaphore;
+
+        // If the process is short-lived, try to enter the short-lived extra semaphore without waiting.
+        if (lifetime is ProcessLifetime.ShortLived && _shortLivedProcessesSemaphore.Wait(0, cancellationToken: default))
+            return _shortLivedProcessesSemaphore;
 
         // Notify that we could not get a process slot immediately and have to start queueing.
         if (queueingCallback is not null)
@@ -38,20 +53,39 @@ internal static class ProcessUtils
         // We always want to notify when we stop queueing; use a try/finally for that.
         try
         {
-            // Otherwise, wait asynchronously for availability.
-            // Note: short-lived processes have their own semaphore to avoid being blocked by long-running ones, but if the process is not actually short-lived,
-            // the queue to run short-lived processes quickly may get starved as there's only one slot available for quick running.
-            var semaphore = isShortLived ? _shortLivedProcessesSemaphore : processesSemaphore;
+            // Otherwise, wait asynchronously for availability on the process's own tier semaphore.
+            // Note: short/medium-lived processes have their own semaphores to avoid being blocked by long-running ones, but if the process is not actually
+            // short/medium-lived, the queue to run such processes quickly may get starved as there's only one slot available per tier for quick running.
+            var semaphore = lifetime switch
+            {
+                ProcessLifetime.ShortLived => _shortLivedProcessesSemaphore,
+                ProcessLifetime.MediumLived => _mediumLivedProcessesSemaphore,
+                ProcessLifetime.CheapLongLived => _cheapLongLivedProcessesSemaphore,
+                _ => processesSemaphore,
+            };
+
             if (runAsynchronously) await semaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
             else semaphore.Wait(cancellationToken);
 
-            // If we entered the short-lived semaphore but a slot is available in the main semaphore, switch to that one.
+            // If we entered an extra tier semaphore but a slot is available in a longer tier (main first, then cheap long, then medium over short), switch to
+            // that one.
             try
             {
-                if (semaphore == _shortLivedProcessesSemaphore && processesSemaphore.Wait(0, cancellationToken: default))
+                if (semaphore != processesSemaphore && processesSemaphore.Wait(0, cancellationToken: default))
                 {
-                    _shortLivedProcessesSemaphore.Release();
+                    semaphore.Release();
                     semaphore = processesSemaphore;
+                }
+                else if ((semaphore == _mediumLivedProcessesSemaphore || semaphore == _shortLivedProcessesSemaphore) &&
+                    _cheapLongLivedProcessesSemaphore.Wait(0, cancellationToken: default))
+                {
+                    semaphore.Release();
+                    semaphore = _cheapLongLivedProcessesSemaphore;
+                }
+                else if (semaphore == _shortLivedProcessesSemaphore && _mediumLivedProcessesSemaphore.Wait(0, cancellationToken: default))
+                {
+                    semaphore.Release();
+                    semaphore = _mediumLivedProcessesSemaphore;
                 }
             }
             catch
@@ -118,7 +152,7 @@ internal static class ProcessUtils
         IEnumerable<string> arguments,
         TextWriter? standardOutputWriter,
         TextWriter? standardErrorWriter,
-        bool isShortLived,
+        ProcessLifetime lifetime,
         bool redirectOutputContinually,
         bool runAsynchronously,
         Func<bool, ValueTask>? queueingCallback, // true means queued, false means dequeued - not called if never queued.
@@ -130,7 +164,7 @@ internal static class ProcessUtils
 
         try
         {
-            var semaphore = await JoinProcessSemaphoreAsync(isShortLived, runAsynchronously, queueingCallback, cancellationToken).ConfigureAwait(false);
+            var semaphore = await JoinProcessSemaphoreAsync(lifetime, runAsynchronously, queueingCallback, cancellationToken).ConfigureAwait(false);
             try
             {
                 process = new Process
@@ -233,7 +267,7 @@ internal static class ProcessUtils
     public static async ValueTask<(string Output, string Error, int ReturnCode)> RunProcessToStringAsync(
         IAbsoluteFilePath fileName,
         IEnumerable<string> arguments,
-        bool isShortLived = false,
+        ProcessLifetime lifetime = ProcessLifetime.LongLived,
         Func<bool, ValueTask>? queueingCallback = null, // true means queued, false means dequeued - not called if never queued.
         CancellationToken cancellationToken = default,
         bool runAsynchronously = true)
@@ -246,7 +280,7 @@ internal static class ProcessUtils
             arguments,
             standardOutputWriter,
             standardErrorWriter,
-            isShortLived,
+            lifetime,
             redirectOutputContinually: false,
             runAsynchronously,
             queueingCallback,
@@ -258,7 +292,7 @@ internal static class ProcessUtils
     public static async ValueTask<string> RunProcessToStringWithErrorHandlingAsync(
         IAbsoluteFilePath fileName,
         IEnumerable<string> arguments,
-        bool isShortLived = false,
+        ProcessLifetime lifetime = ProcessLifetime.LongLived,
         Func<bool, ValueTask>? queueingCallback = null, // true means queued, false means dequeued - not called if never queued.
         CancellationToken cancellationToken = default,
         bool runAsynchronously = true)
@@ -271,7 +305,7 @@ internal static class ProcessUtils
             arguments,
             standardOutputWriter,
             standardErrorWriter,
-            isShortLived,
+            lifetime,
             redirectOutputContinually: false,
             runAsynchronously,
             queueingCallback,
@@ -308,7 +342,7 @@ internal static class ProcessUtils
         IAbsoluteFilePath fileName,
         IEnumerable<string> arguments,
         TextWriter? standardOutputWriter,
-        bool isShortLived = false,
+        ProcessLifetime lifetime = ProcessLifetime.LongLived,
         bool runAsynchronously = true,
         Func<bool, ValueTask>? queueingCallback = null, // true means queued, false means dequeued - not called if never queued.
         CancellationToken cancellationToken = default)
@@ -320,7 +354,7 @@ internal static class ProcessUtils
             arguments,
             standardOutputWriter,
             standardErrorWriter,
-            isShortLived,
+            lifetime,
             redirectOutputContinually: true,
             runAsynchronously,
             queueingCallback,

--- a/Source/FulcrumFS.Videos/ProcessUtils.cs
+++ b/Source/FulcrumFS.Videos/ProcessUtils.cs
@@ -21,7 +21,7 @@ internal static class ProcessUtils
     private static async ValueTask<SemaphoreSlim> JoinProcessSemaphoreAsync(
         ProcessLifetime lifetime,
         bool runAsynchronously,
-        Func<bool, ValueTask>? queueingCallback, // true means queued, false means dequeued - not called if never queued.
+        Func<bool, ValueTask>? queueingCallback, // true means queued, false means dequeued - may be partially or never called at all.
         CancellationToken cancellationToken)
     {
         // Try to enter the main semaphore without waiting first to avoid unnecessary context switches.
@@ -50,81 +50,55 @@ internal static class ProcessUtils
         if (queueingCallback is not null)
             await queueingCallback(true).ConfigureAwait(false);
 
-        // We always want to notify when we stop queueing; use a try/finally for that.
-        SemaphoreSlim? semaphore = null;
-        bool entered = true;
+        // Otherwise, wait asynchronously for availability on the process's own tier semaphore.
+        // Note: short/medium-lived processes have their own semaphores to avoid being blocked by long-running ones, but if the process is not actually
+        // short/medium-lived, the queue to run such processes quickly may get starved as there's only one slot available per tier for quick running.
+        var semaphore = lifetime switch
+        {
+            ProcessLifetime.ShortLived => _shortLivedProcessesSemaphore,
+            ProcessLifetime.MediumLived => _mediumLivedProcessesSemaphore,
+            ProcessLifetime.CheapLongLived => _cheapLongLivedProcessesSemaphore,
+            _ => processesSemaphore,
+        };
 
+        if (runAsynchronously)
+            await semaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
+        else
+            semaphore.Wait(cancellationToken);
+
+        // If we entered an extra tier semaphore but a slot is available in a longer tier (main first, then cheap long, then medium over short), switch to
+        // that one.
         try
         {
-            // Otherwise, wait asynchronously for availability on the process's own tier semaphore.
-            // Note: short/medium-lived processes have their own semaphores to avoid being blocked by long-running ones, but if the process is not actually
-            // short/medium-lived, the queue to run such processes quickly may get starved as there's only one slot available per tier for quick running.
-            semaphore = lifetime switch
-            {
-                ProcessLifetime.ShortLived => _shortLivedProcessesSemaphore,
-                ProcessLifetime.MediumLived => _mediumLivedProcessesSemaphore,
-                ProcessLifetime.CheapLongLived => _cheapLongLivedProcessesSemaphore,
-                _ => processesSemaphore,
-            };
-
-            if (runAsynchronously)
-                await semaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
-            else
-                semaphore.Wait(cancellationToken);
-
-            entered = true;
-
-            // If we entered an extra tier semaphore but a slot is available in a longer tier (main first, then cheap long, then medium over short), switch to
-            // that one.
-            try
-            {
-                if (semaphore != processesSemaphore && processesSemaphore.Wait(0, cancellationToken: default))
-                {
-                    semaphore.Release();
-                    semaphore = processesSemaphore;
-                }
-                else if ((semaphore == _mediumLivedProcessesSemaphore || semaphore == _shortLivedProcessesSemaphore) &&
-                    _cheapLongLivedProcessesSemaphore.Wait(0, cancellationToken: default))
-                {
-                    semaphore.Release();
-                    semaphore = _cheapLongLivedProcessesSemaphore;
-                }
-                else if (semaphore == _shortLivedProcessesSemaphore && _mediumLivedProcessesSemaphore.Wait(0, cancellationToken: default))
-                {
-                    semaphore.Release();
-                    semaphore = _mediumLivedProcessesSemaphore;
-                }
-            }
-            catch
+            if (semaphore != processesSemaphore && processesSemaphore.Wait(0, cancellationToken: default))
             {
                 semaphore.Release();
-                entered = false;
-                throw;
+                semaphore = processesSemaphore;
             }
-
-            // Return the semaphore we acquired.
-            return semaphore;
+            else if ((semaphore == _mediumLivedProcessesSemaphore || semaphore == _shortLivedProcessesSemaphore) &&
+                _cheapLongLivedProcessesSemaphore.Wait(0, cancellationToken: default))
+            {
+                semaphore.Release();
+                semaphore = _cheapLongLivedProcessesSemaphore;
+            }
+            else if (semaphore == _shortLivedProcessesSemaphore && _mediumLivedProcessesSemaphore.Wait(0, cancellationToken: default))
+            {
+                semaphore.Release();
+                semaphore = _mediumLivedProcessesSemaphore;
+            }
         }
-        finally
+        catch
         {
-            // Notify that we finished queueing and got a process slot.
-            try
-            {
-                if (queueingCallback is not null)
-                    await queueingCallback(false).ConfigureAwait(false);
-            }
-            catch
-            {
-                // Ensure we don't leave the semaphore acquired if the queueing callback throws an exception.
-                // Note: we shouldn't ever get here anyway, so also include a debug assertion; this is just for safety in Release mode really.
-                Debug.Fail("Queueing callback threw an exception.");
-
-                if (entered)
-                    semaphore?.Release();
-
-                throw;
-            }
+            semaphore.Release();
+            throw;
         }
+
+        // We successfully acquired a semaphore slot, so notify that we are dequeued if applicable.
+        if (queueingCallback is not null)
+            await queueingCallback(false).ConfigureAwait(false);
+
+        // Return the semaphore we acquired.
+        return semaphore;
     }
 
     private static void KillProcessSafely(Process process)
@@ -177,7 +151,7 @@ internal static class ProcessUtils
         ProcessLifetime lifetime,
         bool redirectOutputContinually,
         bool runAsynchronously,
-        Func<bool, ValueTask>? queueingCallback, // true means queued, false means dequeued - not called if never queued.
+        Func<bool, ValueTask>? queueingCallback, // true means queued, false means dequeued - may be partially or never called at all.
         CancellationToken cancellationToken)
     {
         List<Task>? redirectTasks = null;
@@ -290,7 +264,7 @@ internal static class ProcessUtils
         IAbsoluteFilePath fileName,
         IEnumerable<string> arguments,
         ProcessLifetime lifetime = ProcessLifetime.LongLived,
-        Func<bool, ValueTask>? queueingCallback = null, // true means queued, false means dequeued - not called if never queued.
+        Func<bool, ValueTask>? queueingCallback = null, // true means queued, false means dequeued - may be partially or never called at all.
         CancellationToken cancellationToken = default,
         bool runAsynchronously = true)
     {
@@ -315,7 +289,7 @@ internal static class ProcessUtils
         IAbsoluteFilePath fileName,
         IEnumerable<string> arguments,
         ProcessLifetime lifetime = ProcessLifetime.LongLived,
-        Func<bool, ValueTask>? queueingCallback = null, // true means queued, false means dequeued - not called if never queued.
+        Func<bool, ValueTask>? queueingCallback = null, // true means queued, false means dequeued - may be partially or never called at all.
         CancellationToken cancellationToken = default,
         bool runAsynchronously = true)
     {
@@ -366,7 +340,7 @@ internal static class ProcessUtils
         TextWriter? standardOutputWriter,
         ProcessLifetime lifetime = ProcessLifetime.LongLived,
         bool runAsynchronously = true,
-        Func<bool, ValueTask>? queueingCallback = null, // true means queued, false means dequeued - not called if never queued.
+        Func<bool, ValueTask>? queueingCallback = null, // true means queued, false means dequeued - may be partially or never called at all.
         CancellationToken cancellationToken = default)
     {
         using StringWriter standardErrorWriter = new();

--- a/Source/FulcrumFS.Videos/ProcessUtils.cs
+++ b/Source/FulcrumFS.Videos/ProcessUtils.cs
@@ -27,12 +27,15 @@ internal static class ProcessUtils
         // Try to enter the main semaphore without waiting first to avoid unnecessary context switches.
         // Note: short/medium-lived can still use the main semaphore if available, we are just trying to prioritize them running since they're faster to allow
         // tasks to continue asap & not be blocked by a set of long renders for example.
-        // Note: we preferentially use more constrained semaphores always; this ensures that we don't try to get too far into too many tasks at once such that
-        // they all slow down / queue repeatedly; it tries to limit slowdown / queueing to happening fewer times overall, even if for a bit longer, and to
-        // reduce slowdown of already-running things by minimizing number of extra tasks above normal, while keeping the benefits of getting quicker things done
+        // Note: we preferentially use more constrained (i.e., ones that are more likely to be wanted to be used, such as the main one; not constrained in terms
+        // of what is able to use the semaphore) semaphores always; this ensures that we don't try to get too far into too many tasks at once such that they all
+        // slow down / queue repeatedly; it tries to limit slowdown / queueing to happening fewer times overall, even if for a bit longer, and to reduce
+        // slowdown of already-running things by minimizing number of extra tasks above normal, while keeping the benefits of getting quicker things done
         // quickly.
+
         var processesSemaphore = ProcessesSemaphore;
-        if (processesSemaphore.Wait(0, cancellationToken: default)) return processesSemaphore;
+        if (processesSemaphore.Wait(0, cancellationToken: default))
+            return processesSemaphore;
 
         // If the process is not fully long-lived, try to enter the cheap long-lived extra semaphore without waiting.
         if (lifetime is not ProcessLifetime.LongLived && _cheapLongLivedProcessesSemaphore.Wait(0, cancellationToken: default))
@@ -267,6 +270,8 @@ internal static class ProcessUtils
     }
 
     // Note about queueingCallback: true means queued, false means dequeued - not called when never queued, and always called with false, even when throwing.
+    // - Throwing from queueingCallback results in undefined behavior.
+    // - If runAsynchronously is false, the callback should not yield (not a correctness issue though, just means we run on the thread pool instead).
 
     public static async ValueTask<(string Output, string Error, int ReturnCode)> RunProcessToStringAsync(
         IAbsoluteFilePath fileName,

--- a/Source/FulcrumFS.Videos/VideoFrameExtractionProcessor.cs
+++ b/Source/FulcrumFS.Videos/VideoFrameExtractionProcessor.cs
@@ -159,6 +159,8 @@ public sealed class VideoFrameExtractionProcessor : FileProcessor
         {
             try
             {
+                // Note: we use medium lived as we don't want to block on waiting for a video render, meaning we don't have to implement any progress reporting
+                // as we shouldn't be queued for an unreasonable amount of time.
                 await FFmpegUtils.RunFFmpegCommandAsync(
                     new FFmpegUtils.FFmpegCommand(
                         inputFiles: [(inputFile, Seek: seek)],
@@ -178,6 +180,7 @@ public sealed class VideoFrameExtractionProcessor : FileProcessor
                         isToMov: false),
                     null,
                     null,
+                    lifetime: ProcessLifetime.MediumLived,
                     cancellationToken: context.CancellationToken)
                 .ConfigureAwait(false);
             }

--- a/Source/FulcrumFS.Videos/VideoFrameExtractionProcessor.cs
+++ b/Source/FulcrumFS.Videos/VideoFrameExtractionProcessor.cs
@@ -178,7 +178,7 @@ public sealed class VideoFrameExtractionProcessor : FileProcessor
                         isToMov: false),
                     null,
                     null,
-                    context.CancellationToken)
+                    cancellationToken: context.CancellationToken)
                 .ConfigureAwait(false);
             }
             catch (Exception ex) when (ex is not OperationCanceledException)

--- a/Source/FulcrumFS.Videos/VideoProcessor.cs
+++ b/Source/FulcrumFS.Videos/VideoProcessor.cs
@@ -200,7 +200,30 @@ public sealed class VideoProcessor : FileProcessor
         var progressCallback = context.ProgressCallback;
 
         // Get the queueing callback, which sets the stage display message to Queued while waiting for a process allocation:
-        var queueingCallback = GetQueueingCallback(context);
+        Func<bool, ValueTask>? queueingCallback = null;
+
+        if (context.ProgressDisplayMessageCallback is { } displayMessageCallback)
+        {
+            bool currentlyQueued = false;
+
+            queueingCallback = async (queued) =>
+            {
+                if (currentlyQueued == queued)
+                    return;
+
+                currentlyQueued = queued;
+
+                if (queued)
+                {
+                    await displayMessageCallback(QueuedStageDisplayMessage).ConfigureAwait(false);
+                }
+                else
+                {
+                    await displayMessageCallback(null).ConfigureAwait(false);
+                }
+            };
+        }
+
 #if DEBUG
         // In debug mode, we will check that what we report to the callback is sensible.
         // The callback would fix up some issues anyway, but since our logic is so complicated, we want to have parity with before the new callback approach and
@@ -464,6 +487,7 @@ public sealed class VideoProcessor : FileProcessor
                 sourceInfo.Streams.Length,
                 progressTempFile,
                 countDuration,
+                queueingCallback,
                 context.CancellationToken).ConfigureAwait(false);
 
             streamsValidated += mappedInputIndicesOrdered.Length;
@@ -2082,6 +2106,10 @@ public sealed class VideoProcessor : FileProcessor
                 // This way we optimise the common case of no validation errors, while still executing as if we checked beforehand.
                 context.CancellationToken.ThrowIfCancellationRequested();
 
+                // Dequeue is not reported on exceptions, so ensure we are not left showing as queued while we continue with validation:
+                if (queueingCallback is not null)
+                    await queueingCallback(false).ConfigureAwait(false);
+
                 Func<double, ValueTask>? progressCallback2 = progressCallback is not null
                     ? async (double fraction) =>
                         await progressCallback(mostRecentClampedProgress + (fraction * (1.0 - mostRecentClampedProgress))).ConfigureAwait(false)
@@ -2105,6 +2133,7 @@ public sealed class VideoProcessor : FileProcessor
                     totalStreamCount: streamsValidatedImplicitly.Count,
                     progressTempFile,
                     reportDuration: false,
+                    queueingCallback,
                     context.CancellationToken).ConfigureAwait(false);
 
                 // If we got here, it was not a validation failure, re-throw the original exception:
@@ -2853,15 +2882,6 @@ public sealed class VideoProcessor : FileProcessor
 
     private static string NullDevicePath => OperatingSystem.IsWindows() ? "NUL" : "/dev/null";
 
-    // Gets a queueing callback that sets the stage display message to Queued while waiting for a process allocation (and clears it when one is acquired),
-    // or null if no display message callback is available.
-    private static Func<bool, ValueTask>? GetQueueingCallback(FileProcessingContext context)
-    {
-        return context.ProgressDisplayMessageCallback is { } displayMessageCallback
-            ? (queued) => displayMessageCallback(queued ? QueuedStageDisplayMessage : null)
-            : null;
-    }
-
     // This helper implements the logic for the ForceValidateAllStreams check. We separate it out into a helper so we can call it more cleverly.
     // In particular: since we expect it to be an edge case where it actually fails, we try to avoid doing it as much as possible, and try to do it as late as
     // possible. For when validating stream length thoroughly, we will call it early still, but otherwise we rely on the main processing pass to receive an
@@ -2884,6 +2904,7 @@ public sealed class VideoProcessor : FileProcessor
             int totalStreamCount,
             IAbsoluteFilePath? progressTempFile,
             bool reportDuration,
+            Func<bool, ValueTask>? queueingCallback,
             CancellationToken cancellationToken)
     {
         // First check if we're in a no-op case:
@@ -2896,9 +2917,6 @@ public sealed class VideoProcessor : FileProcessor
                 progressTempFile,
                 progressUsed + ((double)mappedStreamCount / totalStreamCount * ValidateProgressFraction));
         }
-
-        // Get the queueing callback, which sets the stage display message to Queued while waiting for a process allocation:
-        var queueingCallback = GetQueueingCallback(context);
 
         // Validate input by doing a decode-only ffmpeg run to ensure no decoding errors.
         // Note: when active, we set aside the first 20% of progress for this.
@@ -2983,6 +3001,11 @@ public sealed class VideoProcessor : FileProcessor
                 // If we get an exception here, we should try again & specify codecs for each stream, as sometimes ffmpeg doesn't want to auto-select properly
                 // (we don't do this by default since it's more expensive):
                 // Note: we only do this if there is at least one non-subtitle stream, since we already handle those above.
+
+                // Dequeue is not reported on exceptions, so ensure we are not left showing as queued while we retry (the retry re-reports if it queues again):
+                if (queueingCallback is not null)
+                    await queueingCallback(false).ConfigureAwait(false);
+
                 await FFmpegUtils.RunRawFFmpegCommandAsync(
                     [
                         "-i",
@@ -3024,6 +3047,10 @@ public sealed class VideoProcessor : FileProcessor
         {
             // Keep / re-throw exception if cancellation was requested by the caller only, discard if it was our early exit.
             if (cancellationToken.IsCancellationRequested) throw new OperationCanceledException(message: null, ex, cancellationToken);
+
+            // Dequeue is not reported on exceptions, so ensure we are not left showing as queued while we continue after the early exit:
+            if (queueingCallback is not null)
+                await queueingCallback(false).ConfigureAwait(false);
         }
         catch (Exception ex)
         {

--- a/Source/FulcrumFS.Videos/VideoProcessor.cs
+++ b/Source/FulcrumFS.Videos/VideoProcessor.cs
@@ -14,6 +14,11 @@ namespace FulcrumFS.Videos;
 /// </summary>
 public sealed class VideoProcessor : FileProcessor
 {
+    /// <summary>
+    /// The stage display message reported while processing is waiting in the queue for an available ffmpeg process slot.
+    /// </summary>
+    public const string QueuedStageDisplayMessage = "Queued";
+
     private static InterlockedFlag _ffmpegPathInitialized;
 
     /// <summary>
@@ -188,6 +193,9 @@ public sealed class VideoProcessor : FileProcessor
     {
         // Get the progress callback:
         var progressCallback = context.ProgressCallback;
+
+        // Get the queueing callback, which sets the stage display message to Queued while waiting for a process allocation:
+        var queueingCallback = GetQueueingCallback(context);
 #if DEBUG
         // In debug mode, we will check that what we report to the callback is sensible.
         // The callback would fix up some issues anyway, but since our logic is so complicated, we want to have parity with before the new callback approach and
@@ -958,6 +966,7 @@ public sealed class VideoProcessor : FileProcessor
                 var (_, _, returnCode) = await ProcessUtils.RunProcessToStringAsync(
                     FFmpegExePath,
                     testCommand,
+                    queueingCallback: queueingCallback,
                     cancellationToken: context.CancellationToken)
                 .ConfigureAwait(false);
 
@@ -972,6 +981,7 @@ public sealed class VideoProcessor : FileProcessor
                     (_, _, returnCode) = await ProcessUtils.RunProcessToStringAsync(
                         FFmpegExePath,
                         testCommand,
+                        queueingCallback: queueingCallback,
                         cancellationToken: context.CancellationToken)
                     .ConfigureAwait(false);
                     isCompatibleSubtitleStreamAfterReencodingToMovText[i] = returnCode == 0;
@@ -985,6 +995,7 @@ public sealed class VideoProcessor : FileProcessor
                         (_, _, returnCode) = await ProcessUtils.RunProcessToStringAsync(
                             FFmpegExePath,
                             testCommand,
+                            queueingCallback: queueingCallback,
                             cancellationToken: context.CancellationToken)
                         .ConfigureAwait(false);
                         isCompatibleSubtitleStreamAfterReencodingToDvdSubtitle[i] = returnCode == 0;
@@ -2050,6 +2061,7 @@ public sealed class VideoProcessor : FileProcessor
                     command,
                     localProgressCallback,
                     localProgressCallback != null ? progressTempFile : null,
+                    queueingCallback,
                     context.CancellationToken)
                 .ConfigureAwait(false);
             }
@@ -2153,7 +2165,7 @@ public sealed class VideoProcessor : FileProcessor
                     isToMov: true);
                 try
                 {
-                    await FFmpegUtils.RunFFmpegCommandAsync(extractCommandReencoded, null, null, context.CancellationToken).ConfigureAwait(false);
+                    await FFmpegUtils.RunFFmpegCommandAsync(extractCommandReencoded, null, null, queueingCallback, context.CancellationToken).ConfigureAwait(false);
                 }
                 catch (Exception ex) when (ex is not OperationCanceledException)
                 {
@@ -2201,7 +2213,7 @@ public sealed class VideoProcessor : FileProcessor
                     isToMov: true);
                 try
                 {
-                    await FFmpegUtils.RunFFmpegCommandAsync(extractCommandOriginal, null, null, context.CancellationToken).ConfigureAwait(false);
+                    await FFmpegUtils.RunFFmpegCommandAsync(extractCommandOriginal, null, null, queueingCallback, context.CancellationToken).ConfigureAwait(false);
                 }
                 catch (Exception ex) when (ex is not OperationCanceledException)
                 {
@@ -2372,6 +2384,7 @@ public sealed class VideoProcessor : FileProcessor
                         mixCommand,
                         localProgressCallbackInner,
                         localProgressCallbackInner != null ? progressTempFile : null,
+                        queueingCallback,
                         context.CancellationToken)
                     .ConfigureAwait(false);
                 }
@@ -2812,6 +2825,15 @@ public sealed class VideoProcessor : FileProcessor
 
     private static string NullDevicePath => OperatingSystem.IsWindows() ? "NUL" : "/dev/null";
 
+    // Gets a queueing callback that sets the stage display message to Queued while waiting for a process allocation (and clears it when one is acquired),
+    // or null if no display message callback is available.
+    private static Func<bool, ValueTask>? GetQueueingCallback(FileProcessingContext context)
+    {
+        return context.ProgressDisplayMessageCallback is { } displayMessageCallback
+            ? (queued) => displayMessageCallback(queued ? QueuedStageDisplayMessage : null)
+            : null;
+    }
+
     // This helper implements the logic for the ForceValidateAllStreams check. We separate it out into a helper so we can call it more cleverly.
     // In particular: since we expect it to be an edge case where it actually fails, we try to avoid doing it as much as possible, and try to do it as late as
     // possible. For when validating stream length thoroughly, we will call it early still, but otherwise we rely on the main processing pass to receive an
@@ -2846,6 +2868,9 @@ public sealed class VideoProcessor : FileProcessor
                 progressTempFile,
                 progressUsed + ((double)mappedStreamCount / totalStreamCount * ValidateProgressFraction));
         }
+
+        // Get the queueing callback, which sets the stage display message to Queued while waiting for a process allocation:
+        var queueingCallback = GetQueueingCallback(context);
 
         // Validate input by doing a decode-only ffmpeg run to ensure no decoding errors.
         // Note: when active, we set aside the first 20% of progress for this.
@@ -2918,6 +2943,7 @@ public sealed class VideoProcessor : FileProcessor
                     validateProgressCallback,
                     validateProgressCallback is null ? null : progressTempFile,
                     ensureAllProgressRead: reportDuration,
+                    queueingCallback: queueingCallback,
                     cancellationToken: linkedCts.Token)
                 .ConfigureAwait(false);
             }
@@ -2961,6 +2987,7 @@ public sealed class VideoProcessor : FileProcessor
                     validateProgressCallback,
                     validateProgressCallback is null ? null : progressTempFile,
                     ensureAllProgressRead: reportDuration,
+                    queueingCallback: queueingCallback,
                     cancellationToken: linkedCts.Token)
                 .ConfigureAwait(false);
             }

--- a/Source/FulcrumFS.Videos/VideoProcessor.cs
+++ b/Source/FulcrumFS.Videos/VideoProcessor.cs
@@ -159,9 +159,14 @@ public sealed class VideoProcessor : FileProcessor
     /// <para>
     /// On Linux/macOS: should contain ffmpeg and ffprobe executables with appropriate execute permissions.</para>
     /// </summary>
-    /// <param name="dirPath">The directory path containing the ffmpeg executables.</param>
-    /// <param name="maxConcurrentProcesses">The maximum number of concurrent ffmpeg processes to allow. Default is currently
-    /// <see cref="Environment.ProcessorCount" />. Note: there is an additional process added used for short-lived processes.</param>
+    /// <param name="dirPath">
+    /// The directory path containing the ffmpeg executables.
+    /// </param>
+    /// <param name="maxConcurrentProcesses">
+    /// The maximum number of concurrent ffmpeg processes to allow. Default is currently <see cref="Environment.ProcessorCount" />. Note: there are a small set
+    /// of additional processes added used for short-to-medium-lived processes. In common usage, the limit will represent the actual number of concurrent
+    /// processes, with occasional relatively short-lived / low resource processes being able to run on top of that to not block finishing off those tasks.
+    /// </param>
     public static void ConfigureWithFFmpegExecutables(IAbsoluteDirectoryPath dirPath, int maxConcurrentProcesses = -1)
     {
         var (ffmpeg, ffprobe) = OperatingSystem.IsWindows()
@@ -963,9 +968,11 @@ public sealed class VideoProcessor : FileProcessor
                 IEnumerable<string> testCommand = BuildStreamCompatibilityTestCommand(codec: "copy", shortSegment: false);
 
                 // Run the test command:
+                // Note: we use cheap long lived as this is a cheap copy-based test run that shouldn't have to queue behind unrelated long renders.
                 var (_, _, returnCode) = await ProcessUtils.RunProcessToStringAsync(
                     FFmpegExePath,
                     testCommand,
+                    lifetime: ProcessLifetime.CheapLongLived,
                     queueingCallback: queueingCallback,
                     cancellationToken: context.CancellationToken)
                 .ConfigureAwait(false);
@@ -978,9 +985,11 @@ public sealed class VideoProcessor : FileProcessor
                     testCommand = BuildStreamCompatibilityTestCommand(codec: "mov_text", shortSegment: true);
 
                     // Run the test command:
+                    // Note: we use cheap long lived as this is a cheap short-segment test run that shouldn't have to queue behind unrelated long renders.
                     (_, _, returnCode) = await ProcessUtils.RunProcessToStringAsync(
                         FFmpegExePath,
                         testCommand,
+                        lifetime: ProcessLifetime.CheapLongLived,
                         queueingCallback: queueingCallback,
                         cancellationToken: context.CancellationToken)
                     .ConfigureAwait(false);
@@ -992,9 +1001,11 @@ public sealed class VideoProcessor : FileProcessor
                         testCommand = BuildStreamCompatibilityTestCommand(codec: "dvd_subtitle", shortSegment: true);
 
                         // Run the test command:
+                        // Note: we use cheap long lived as this is a cheap short-segment test run that shouldn't have to queue behind unrelated long renders.
                         (_, _, returnCode) = await ProcessUtils.RunProcessToStringAsync(
                             FFmpegExePath,
                             testCommand,
+                            lifetime: ProcessLifetime.CheapLongLived,
                             queueingCallback: queueingCallback,
                             cancellationToken: context.CancellationToken)
                         .ConfigureAwait(false);
@@ -2062,7 +2073,7 @@ public sealed class VideoProcessor : FileProcessor
                     localProgressCallback,
                     localProgressCallback != null ? progressTempFile : null,
                     queueingCallback,
-                    context.CancellationToken)
+                    cancellationToken: context.CancellationToken)
                 .ConfigureAwait(false);
             }
             catch (Exception ex) when (ex is not OperationCanceledException && Options.ForceValidateAllStreams && streamsValidatedImplicitly.Count > 0)
@@ -2165,7 +2176,8 @@ public sealed class VideoProcessor : FileProcessor
                     isToMov: true);
                 try
                 {
-                    await FFmpegUtils.RunFFmpegCommandAsync(extractCommandReencoded, null, null, queueingCallback, context.CancellationToken).ConfigureAwait(false);
+                    // Note: we use cheap long lived as this is a cheap copy-based extraction that shouldn't have to queue behind unrelated long renders.
+                    await FFmpegUtils.RunFFmpegCommandAsync(extractCommandReencoded, null, null, queueingCallback, ProcessLifetime.CheapLongLived, cancellationToken: context.CancellationToken).ConfigureAwait(false);
                 }
                 catch (Exception ex) when (ex is not OperationCanceledException)
                 {
@@ -2213,7 +2225,8 @@ public sealed class VideoProcessor : FileProcessor
                     isToMov: true);
                 try
                 {
-                    await FFmpegUtils.RunFFmpegCommandAsync(extractCommandOriginal, null, null, queueingCallback, context.CancellationToken).ConfigureAwait(false);
+                    // Note: we use cheap long lived as this is a cheap copy-based extraction that shouldn't have to queue behind unrelated long renders.
+                    await FFmpegUtils.RunFFmpegCommandAsync(extractCommandOriginal, null, null, queueingCallback, ProcessLifetime.CheapLongLived, cancellationToken: context.CancellationToken).ConfigureAwait(false);
                 }
                 catch (Exception ex) when (ex is not OperationCanceledException)
                 {
@@ -2380,12 +2393,14 @@ public sealed class VideoProcessor : FileProcessor
 
                 try
                 {
+                    // Note: we use cheap long lived as this is a cheap copy-based recombination that shouldn't have to queue behind unrelated long renders.
                     await FFmpegUtils.RunFFmpegCommandAsync(
                         mixCommand,
                         localProgressCallbackInner,
                         localProgressCallbackInner != null ? progressTempFile : null,
                         queueingCallback,
-                        context.CancellationToken)
+                        ProcessLifetime.CheapLongLived,
+                        cancellationToken: context.CancellationToken)
                     .ConfigureAwait(false);
                 }
                 catch (Exception ex) when (ex is not OperationCanceledException)

--- a/Source/FulcrumFS.Videos/VideoProcessor.cs
+++ b/Source/FulcrumFS.Videos/VideoProcessor.cs
@@ -2106,10 +2106,6 @@ public sealed class VideoProcessor : FileProcessor
                 // This way we optimise the common case of no validation errors, while still executing as if we checked beforehand.
                 context.CancellationToken.ThrowIfCancellationRequested();
 
-                // Dequeue is not reported on exceptions, so ensure we are not left showing as queued while we continue with validation:
-                if (queueingCallback is not null)
-                    await queueingCallback(false).ConfigureAwait(false);
-
                 Func<double, ValueTask>? progressCallback2 = progressCallback is not null
                     ? async (double fraction) =>
                         await progressCallback(mostRecentClampedProgress + (fraction * (1.0 - mostRecentClampedProgress))).ConfigureAwait(false)
@@ -3001,10 +2997,6 @@ public sealed class VideoProcessor : FileProcessor
                 // If we get an exception here, we should try again & specify codecs for each stream, as sometimes ffmpeg doesn't want to auto-select properly
                 // (we don't do this by default since it's more expensive):
                 // Note: we only do this if there is at least one non-subtitle stream, since we already handle those above.
-
-                // Dequeue is not reported on exceptions, so ensure we are not left showing as queued while we retry (the retry re-reports if it queues again):
-                if (queueingCallback is not null)
-                    await queueingCallback(false).ConfigureAwait(false);
 
                 await FFmpegUtils.RunRawFFmpegCommandAsync(
                     [

--- a/Source/FulcrumFS.Videos/VideoProcessor.cs
+++ b/Source/FulcrumFS.Videos/VideoProcessor.cs
@@ -2177,7 +2177,13 @@ public sealed class VideoProcessor : FileProcessor
                 try
                 {
                     // Note: we use cheap long lived as this is a cheap copy-based extraction that shouldn't have to queue behind unrelated long renders.
-                    await FFmpegUtils.RunFFmpegCommandAsync(extractCommandReencoded, null, null, queueingCallback, ProcessLifetime.CheapLongLived, cancellationToken: context.CancellationToken).ConfigureAwait(false);
+                    await FFmpegUtils.RunFFmpegCommandAsync(
+                        extractCommandReencoded,
+                        null,
+                        null,
+                        queueingCallback, ProcessLifetime.CheapLongLived,
+                        cancellationToken: context.CancellationToken)
+                    .ConfigureAwait(false);
                 }
                 catch (Exception ex) when (ex is not OperationCanceledException)
                 {
@@ -2226,7 +2232,14 @@ public sealed class VideoProcessor : FileProcessor
                 try
                 {
                     // Note: we use cheap long lived as this is a cheap copy-based extraction that shouldn't have to queue behind unrelated long renders.
-                    await FFmpegUtils.RunFFmpegCommandAsync(extractCommandOriginal, null, null, queueingCallback, ProcessLifetime.CheapLongLived, cancellationToken: context.CancellationToken).ConfigureAwait(false);
+                    await FFmpegUtils.RunFFmpegCommandAsync(
+                        extractCommandOriginal,
+                        null,
+                        null,
+                        queueingCallback,
+                        ProcessLifetime.CheapLongLived,
+                        cancellationToken: context.CancellationToken)
+                    .ConfigureAwait(false);
                 }
                 catch (Exception ex) when (ex is not OperationCanceledException)
                 {

--- a/Source/FulcrumFS.Videos/VideoProcessorConfigurationOptions.cs
+++ b/Source/FulcrumFS.Videos/VideoProcessorConfigurationOptions.cs
@@ -10,7 +10,9 @@ public sealed record VideoProcessorConfigurationOptions()
 {
     /// <summary>
     /// Gets or initializes the maximum number of concurrent ffmpeg processes to allow. Default is currently
-    /// <see cref="Environment.ProcessorCount" />. Note: there is an additional process added used for short-lived processes.
+    /// <see cref="Environment.ProcessorCount" />. Note: there are a small set of additional processes added used for short-to-medium-lived processes. In common
+    /// usage, the limit will represent the actual number of concurrent processes, with occasional relatively short-lived / low resource processes being able to
+    /// run on top of that to not block finishing off those tasks.
     /// </summary>
     public int? MaxConcurrentProcesses
     {

--- a/Source/FulcrumFS/FileProcessingContext.cs
+++ b/Source/FulcrumFS/FileProcessingContext.cs
@@ -52,10 +52,31 @@ public sealed class FileProcessingContext : IAsyncDisposable
     /// representing the progress fraction (between 0.0 and 1.0) and returns a <see cref="ValueTask" /> to await.
     /// </summary>
     /// <remarks>
+    /// <para>
     /// This value is only meant to be read by the <see cref="FileProcessor"/> instances in the pipeline. It is set by the <see cref="FileProcessingPipeline" />
     /// before each processor is executed and is not intended to be used outside of this.
+    /// </para>
+    /// <para>
+    /// Should not be called concurrently from multiple threads/tasks.
+    /// </para>
     /// </remarks>
     public Func<double, ValueTask>? ProgressCallback { get; internal set; }
+
+    /// <summary>
+    /// Gets a value that represents the callback function to report an optional informative display message for the current processing stage. The callback
+    /// function takes a string (or <see langword="null"/> to clear the message) and returns a <see cref="ValueTask" /> to await. The message is combined with
+    /// the most recently reported progress fraction when reported to the caller.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This value is only meant to be read by the <see cref="FileProcessor"/> instances in the pipeline. It is set by the <see cref="FileProcessingPipeline" />
+    /// before each processor is executed and is not intended to be used outside of this.
+    /// </para>
+    /// <para>
+    /// Should not be called concurrently from multiple threads/tasks.
+    /// </para>
+    /// </remarks>
+    public Func<string?, ValueTask>? ProgressDisplayMessageCallback { get; internal set; }
 
     internal bool IsSourceInMemoryOrFile => _source is IAbsoluteFilePath or MemoryStream or FileStream;
 

--- a/Source/FulcrumFS/FileProcessingPipeline.cs
+++ b/Source/FulcrumFS/FileProcessingPipeline.cs
@@ -167,6 +167,7 @@ public class FileProcessingPipeline : IFileProcessingPipelineProvider, IFileProc
             var processor = Processors[i];
 
             Func<double, ValueTask>? processorProgressCallback = null;
+            Func<string?, ValueTask>? processorProgressDisplayMessageCallback = null;
 
             // Handle progress reporting if enabled:
             if (progressCallback is not null)
@@ -184,18 +185,31 @@ public class FileProcessingPipeline : IFileProcessingPipelineProvider, IFileProc
                     processorName = string.Create(CultureInfo.InvariantCulture, $"{processorName} ({count + 1})");
                 }
 
-                // Create the callback to use for this one:
+                // State used to combine the processor's separately-reported fraction and display message into single progress values:
+                double currentFraction = 0.0;
+                string? currentMessage = null;
+
+                // Create the callbacks to use for this one:
                 processorProgressCallback = async (fraction) =>
                 {
-                    var progressValue = new ProgressValue(context.VariantId, processorName, fraction);
+                    currentFraction = fraction;
+                    var progressValue = new ProgressValue(context.VariantId, processorName, fraction, currentMessage);
+                    await progressCallback(progressValue).ConfigureAwait(false);
+                };
+
+                processorProgressDisplayMessageCallback = async (message) =>
+                {
+                    currentMessage = message;
+                    var progressValue = new ProgressValue(context.VariantId, processorName, currentFraction, message);
                     await progressCallback(progressValue).ConfigureAwait(false);
                 };
 
                 // Ensure we see some progress for this processor even if it doesn't report any:
                 await processorProgressCallback(0.0).ConfigureAwait(false);
 
-                // Set the callback on the context:
+                // Set the callbacks on the context:
                 context.ProgressCallback = processorProgressCallback;
+                context.ProgressDisplayMessageCallback = processorProgressDisplayMessageCallback;
             }
 
             var result = await processor.CallProcessAsync(context).ConfigureAwait(false);

--- a/Source/FulcrumFS/ProgressValue.cs
+++ b/Source/FulcrumFS/ProgressValue.cs
@@ -1,18 +1,20 @@
 namespace FulcrumFS;
 
 /// <summary>
-/// Represents a progress value for a file processing operation, including the variant ID, stage, and progress fraction.
+/// Represents a progress value for a file processing operation, including the variant ID, stage, progress fraction, and optional stage display message.
 /// </summary>
 public readonly record struct ProgressValue
 {
     /// <summary>
-    /// Initializes a new instance of the <see cref="ProgressValue"/> struct with the specified variant ID, stage, and progress fraction.
+    /// Initializes a new instance of the <see cref="ProgressValue"/> struct with the specified variant ID, stage, progress fraction, and optional stage display
+    /// message.
     /// </summary>
-    internal ProgressValue(string? variantId, string stage, double progress)
+    internal ProgressValue(string? variantId, string stage, double progress, string? stageDisplayMessage = null)
     {
         VariantId = variantId;
         Stage = stage;
         Progress = progress;
+        StageDisplayMessage = stageDisplayMessage;
     }
 
     /// <summary>
@@ -29,4 +31,10 @@ public readonly record struct ProgressValue
     /// Gets the progress fraction of the operation, ranging from 0.0 to 1.0.
     /// </summary>
     public double Progress { get; init; }
+
+    /// <summary>
+    /// Gets an optional informative display message for the current stage, or <see langword="null"/> if no message has been set. This is purely informative and
+    /// does not represent a new stage.
+    /// </summary>
+    public string? StageDisplayMessage { get; init; }
 }

--- a/Source/FulcrumFS/TaskWithProgress.cs
+++ b/Source/FulcrumFS/TaskWithProgress.cs
@@ -234,7 +234,7 @@ public sealed class TaskWithProgress<T> : IAsyncEnumerable<ProgressValue>
                         (progressValue.VariantId, progressValue.Stage, progressValue.Progress, progressValue.StageDisplayMessage);
 
                     // Normalize what report as follows: always report a 0.0 first, and then only ever report in strictly monotonically increasing order, up to
-                    // 1.0 as a maximum (also always reported).
+                    // 1.0 as a maximum (also always reported). Or, if the display message changes, then we allow re-reporting with same progress value.
 
                     // If we got a value outside of [0.0, 1.0] throw an exception:
                     if (progress < 0.0 || progress > 1.0 || double.IsNaN(progress))

--- a/Source/FulcrumFS/TaskWithProgress.cs
+++ b/Source/FulcrumFS/TaskWithProgress.cs
@@ -21,8 +21,9 @@ namespace FulcrumFS;
 /// enumerations concurrently. You can, however, run multiple normal awaits concurrently (like with <see cref="Task{TResult}" />).
 /// </para>
 /// <para>
-/// Progress values for each stage are reported in the range [0.0, 1.0], are strictly monotonically increasing, and always include both 0.0 and 1.0 (unless a
-/// failure occurs partway through).
+/// Progress values for each stage are reported in the range [0.0, 1.0], are monotonically increasing, and always include both 0.0 and 1.0 (unless a
+/// failure occurs partway through). Progress values are strictly increasing except when only the stage display message changes, in which case a value may be
+/// reported that repeats the previous progress fraction with the updated message.
 /// </para>
 /// <para>
 /// If an exception occurs in the underlying operation and it is not observed by the caller through either <see cref="GetAwaiter" /> or
@@ -215,6 +216,7 @@ public sealed class TaskWithProgress<T> : IAsyncEnumerable<ProgressValue>
                 // Local state:
                 bool isCancelledLocal = false;
                 double lastProgressValue = -1.0; // Store last value so we can perform normalization.
+                string? lastMessage = null; // Last reported stage display message (reset for each new stage).
                 string? lastStage = null;
                 string? lastVariantId = null;
                 HashSet<(string? VariantId, string Stage)> reportedStages = [];
@@ -228,7 +230,8 @@ public sealed class TaskWithProgress<T> : IAsyncEnumerable<ProgressValue>
                         isCancelledLocal = true;
 
                     // Read parameter:
-                    var (variantId, stage, progress) = (progressValue.VariantId, progressValue.Stage, progressValue.Progress);
+                    var (variantId, stage, progress, message) =
+                        (progressValue.VariantId, progressValue.Stage, progressValue.Progress, progressValue.StageDisplayMessage);
 
                     // Normalize what report as follows: always report a 0.0 first, and then only ever report in strictly monotonically increasing order, up to
                     // 1.0 as a maximum (also always reported).
@@ -250,7 +253,7 @@ public sealed class TaskWithProgress<T> : IAsyncEnumerable<ProgressValue>
                             {
                                 lock (progressQueueLock)
                                 {
-                                    progressQueue.AddLast(new ProgressValue(lastVariantId, lastStage, 1.0));
+                                    progressQueue.AddLast(new ProgressValue(lastVariantId, lastStage, 1.0, lastMessage));
                                 }
 
                                 progressSemaphore.Release();
@@ -270,17 +273,21 @@ public sealed class TaskWithProgress<T> : IAsyncEnumerable<ProgressValue>
                             lastStage = stage;
                             lastVariantId = variantId;
                             lastProgressValue = -1.0;
+                            lastMessage = null;
                         }
 
                         // Normalize -0.0 to 0.0.
                         if (progress == 0.0)
                             progress = 0.0;
 
-                        // If progress has increased.
-                        if (progress > lastProgressValue)
+                        // If progress has increased or the stage display message has changed.
+                        if (progress > lastProgressValue || message != lastMessage)
                         {
-                            // If we missed 0.0, enqueue it first.
-                            if (lastProgressValue < 0.0 && progress > 0.0)
+                            // Never report a lower progress than what we already reported (message-only updates re-use the last reported progress).
+                            double effectiveProgress = double.Max(progress, lastProgressValue);
+
+                            // If we missed 0.0, enqueue it first (with no message - the reported message only applies from the reported value onward).
+                            if (lastProgressValue < 0.0 && effectiveProgress > 0.0)
                             {
                                 lock (progressQueueLock)
                                 {
@@ -294,24 +301,26 @@ public sealed class TaskWithProgress<T> : IAsyncEnumerable<ProgressValue>
                             bool addedNew = true;
                             lock (progressQueueLock)
                             {
-                                // If we just added one for this before, and nobody has read it yet, then we should just replace that, except for 0.0 and 1.0.
-                                // This ensures our queue doesn't get way fuller than a caller can handle.
-                                // We only do this if we have at least 16 in the current stage in the queue.
-                                if (progressQueue.Count - int.Max(fromPreviousStage - processedSinceNewStage, 0) >= 16 && progressQueue.Last is { Value: ProgressValue lastValue } && lastValue.VariantId == variantId && lastValue.Stage == stage && lastValue.Progress is > 0.0 and < 1.0)
+                                // If we just added one for this before, and nobody has read it yet, then we should just replace that, except for 0.0 and 1.0 -
+                                // however, a message-only update at the same progress (including 0.0 and 1.0) also replaces, since it only refreshes the
+                                // message and never loses a distinct progress value. This ensures our queue doesn't get way fuller than a caller can handle
+                                // (and we only care about the latest message). We only do this if we have at least 16 in the current stage in the queue.
+                                if (progressQueue.Count - int.Max(fromPreviousStage - processedSinceNewStage, 0) >= 16 && progressQueue.Last is { Value: ProgressValue lastValue } && lastValue.VariantId == variantId && lastValue.Stage == stage && (lastValue.Progress is > 0.0 and < 1.0 || lastValue.Progress == effectiveProgress))
                                 {
                                     progressQueue.RemoveLast();
                                     addedNew = false;
                                 }
 
                                 // Add our new value
-                                progressQueue.AddLast(new ProgressValue(variantId, stage, progress));
+                                progressQueue.AddLast(new ProgressValue(variantId, stage, effectiveProgress, message));
                             }
 
                             if (addedNew)
                                 progressSemaphore.Release();
 
-                            // Update the last progress value.
-                            lastProgressValue = progress;
+                            // Update the last progress value and message.
+                            lastProgressValue = effectiveProgress;
+                            lastMessage = message;
                         }
                     }
                 };
@@ -332,7 +341,7 @@ public sealed class TaskWithProgress<T> : IAsyncEnumerable<ProgressValue>
                 {
                     lock (progressQueueLock)
                     {
-                        progressQueue.AddLast(new ProgressValue(lastVariantId, lastStage, 1.0));
+                        progressQueue.AddLast(new ProgressValue(lastVariantId, lastStage, 1.0, lastMessage));
                     }
 
                     progressSemaphore.Release();

--- a/Tests/FulcrumFS.Tests/PipelineProviderTests.cs
+++ b/Tests/FulcrumFS.Tests/PipelineProviderTests.cs
@@ -125,6 +125,30 @@ public sealed class PipelineProviderTests
     }
 
     [TestMethod]
+    public async Task Progress_ProcessorMessage_ReportedWithLatestFraction()
+    {
+        using var repo = CreateRepo();
+        var pipeline = new MessageReportingProcessor().ToPipeline();
+
+        await using var source = File.OpenRead(_sampleDir.CombineFile("sample.jpg").PathExport);
+        await using var txn = await repo.BeginTransactionAsync();
+
+        var progress = new List<ProgressValue>();
+        await foreach (var pv in txn.AddAsync(source, ".jpg", leaveOpen: true, pipeline, TestContext.CancellationToken).WithCancellation(TestContext.CancellationToken))
+            progress.Add(pv);
+
+        await txn.CommitAsync(TestContext.CancellationToken);
+
+        progress.ShouldBe(
+        [
+            new(null, "MessageReportingProcessor", 0.0),
+            new(null, "MessageReportingProcessor", 0.0, "Working"),
+            new(null, "MessageReportingProcessor", 0.5, "Working"),
+            new(null, "MessageReportingProcessor", 1.0, "Working"),
+        ]);
+    }
+
+    [TestMethod]
     public async Task Progress_MultipleProcessors_ReportZeroAndOneForEach()
     {
         using var repo = CreateRepo();

--- a/Tests/FulcrumFS.Tests/TaskWithProgressTests.cs
+++ b/Tests/FulcrumFS.Tests/TaskWithProgressTests.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.Runtime.CompilerServices;
 
 namespace FulcrumFS;
@@ -780,6 +781,167 @@ public sealed class TaskWithProgressTests
         var t = Make([new(null, "A", 0.5), new(null, "B", 0.5), new(null, "A", 0.7)]);
         var ex = await Should.ThrowAsync<InvalidOperationException>(async () => await CollectFullAsync(t, TestContext.CancellationToken));
         ex.Message.ShouldBe("Stage 'A' for variant '' has already been reported.");
+    }
+
+    // --- Stage display messages ---
+
+    [TestMethod]
+    public async Task Message_FlowsThrough_AndAppliesToSynthesizedValues()
+    {
+        var t = Make([new(null, "S", 0.5, "working")]);
+        var p = await CollectFullAsync(t, TestContext.CancellationToken);
+        p.ShouldBe(
+        [
+            new(null, "S", 0.0), // The synthesized 0.0 carries no message - the message only applies from the reported value onward.
+            new(null, "S", 0.5, "working"),
+            new(null, "S", 1.0, "working"),
+        ]);
+    }
+
+    [TestMethod]
+    public async Task Message_OnlyChange_ReportedAtSameProgress()
+    {
+        var t = Make([new(null, "S", 0.5, "a"), new(null, "S", 0.5, "b")]);
+        var p = await CollectFullAsync(t, TestContext.CancellationToken);
+        p.ShouldBe(
+        [
+            new(null, "S", 0.0),
+            new(null, "S", 0.5, "a"),
+            new(null, "S", 0.5, "b"),
+            new(null, "S", 1.0, "b"),
+        ]);
+    }
+
+    [TestMethod]
+    public async Task Message_ChangeWithLowerProgress_ReusesLastProgress()
+    {
+        var t = Make([new(null, "S", 0.5, "a"), new(null, "S", 0.3, "b")]);
+        var p = await CollectFullAsync(t, TestContext.CancellationToken);
+        p.ShouldBe(
+        [
+            new(null, "S", 0.0),
+            new(null, "S", 0.5, "a"),
+            new(null, "S", 0.5, "b"),
+            new(null, "S", 1.0, "b"),
+        ]);
+    }
+
+    [TestMethod]
+    public async Task Message_Unchanged_NonIncreasingProgress_Dropped()
+    {
+        var t = Make([new(null, "S", 0.5, "a"), new(null, "S", 0.5, "a"), new(null, "S", 0.3, "a")]);
+        var p = await CollectFullAsync(t, TestContext.CancellationToken);
+        p.ShouldBe(
+        [
+            new(null, "S", 0.0),
+            new(null, "S", 0.5, "a"),
+            new(null, "S", 1.0, "a"),
+        ]);
+    }
+
+    [TestMethod]
+    public async Task Message_ClearedToNull_Reported()
+    {
+        var t = Make([new(null, "S", 0.5, "a"), new(null, "S", 0.6, null)]);
+        var p = await CollectFullAsync(t, TestContext.CancellationToken);
+        p.ShouldBe(
+        [
+            new(null, "S", 0.0),
+            new(null, "S", 0.5, "a"),
+            new(null, "S", 0.6),
+            new(null, "S", 1.0),
+        ]);
+    }
+
+    [TestMethod]
+    public async Task Message_NewStage_ResetsMessage()
+    {
+        var t = Make([new(null, "A", 0.5, "a"), new(null, "B", 0.5)]);
+        var p = await CollectFullAsync(t, TestContext.CancellationToken);
+        p.ShouldBe(
+        [
+            new(null, "A", 0.0),
+            new(null, "A", 0.5, "a"),
+            new(null, "A", 1.0, "a"), // Stage close carries the last message for the stage.
+            new(null, "B", 0.0),
+            new(null, "B", 0.5),
+            new(null, "B", 1.0),
+        ]);
+    }
+
+    [TestMethod]
+    public async Task Message_BeyondQueueLimit_CoalescedKeepsLatestMessage()
+    {
+        // Same coalescing shape as Progress_BeyondQueueLimit_ExcessCoalescedIntoLastSlot, but each report carries a distinct message: the coalesced tail must
+        // keep the latest message, and the close inherits it.
+        var reports = new List<ProgressValue> { new(null, "S", 0.0, "m0") };
+
+        for (int i = 1; i <= 50; i++)
+            reports.Add(new(null, "S", i / 64.0, string.Create(CultureInfo.InvariantCulture, $"m{i}")));
+
+        var t = Make([.. reports], result: 1);
+        var seen = await CollectAfterCompletionAsync(t);
+
+        var expected = new List<ProgressValue>();
+
+        for (int i = 0; i <= 14; i++)
+            expected.Add(new(null, "S", i / 64.0, string.Create(CultureInfo.InvariantCulture, $"m{i}")));
+
+        expected.Add(new(null, "S", 50 / 64.0, "m50"));
+        expected.Add(new(null, "S", 1.0, "m50"));
+
+        seen.ShouldBe(expected);
+    }
+
+    [TestMethod]
+    public async Task Message_MultipleUpdatesAtOne_BeyondQueueLimit_KeepsOnlyLatest()
+    {
+        // Fill the stage's queue to the 16-item coalescing limit, then report several message-only updates at 1.0: only the latest 1.0 should be kept.
+        var reports = new List<ProgressValue> { new(null, "S", 0.0) };
+
+        for (int i = 1; i <= 15; i++)
+            reports.Add(new(null, "S", i / 64.0));
+
+        reports.Add(new(null, "S", 1.0, "a"));
+        reports.Add(new(null, "S", 1.0, "b"));
+        reports.Add(new(null, "S", 1.0, "c"));
+
+        var t = Make([.. reports], result: 1);
+        var seen = await CollectAfterCompletionAsync(t);
+
+        // 0.0 plus 1/64..14/64 are preserved, 15/64 is coalesced away by the first 1.0, and each subsequent 1.0 replaces the previous one.
+        var expected = new List<ProgressValue>();
+
+        for (int i = 0; i <= 14; i++)
+            expected.Add(new(null, "S", i / 64.0));
+
+        expected.Add(new(null, "S", 1.0, "c"));
+
+        seen.ShouldBe(expected);
+    }
+
+    [TestMethod]
+    public async Task Message_MultipleUpdatesAtZero_BeyondQueueLimit_KeepsOnlyLatest()
+    {
+        // Message-only updates at 0.0 accumulate until the 16-item coalescing limit, after which each replaces the previous queued 0.0.
+        var reports = new List<ProgressValue>();
+
+        for (int i = 0; i <= 20; i++)
+            reports.Add(new(null, "S", 0.0, string.Create(CultureInfo.InvariantCulture, $"m{i}")));
+
+        var t = Make([.. reports], result: 1);
+        var seen = await CollectAfterCompletionAsync(t);
+
+        // m0..m14 fill under the limit, m15 hits the 16th slot, then m16..m20 each replace it, leaving m20; the stage then closes at 1.0 with the last message.
+        var expected = new List<ProgressValue>();
+
+        for (int i = 0; i <= 14; i++)
+            expected.Add(new(null, "S", 0.0, string.Create(CultureInfo.InvariantCulture, $"m{i}")));
+
+        expected.Add(new(null, "S", 0.0, "m20"));
+        expected.Add(new(null, "S", 1.0, "m20"));
+
+        seen.ShouldBe(expected);
     }
 
     // --- Progress queue coalescing ---

--- a/Tests/FulcrumFS.Tests/VariantTestProcessors.cs
+++ b/Tests/FulcrumFS.Tests/VariantTestProcessors.cs
@@ -49,6 +49,27 @@ internal sealed class RewriteProcessor : FileProcessor
 }
 
 /// <summary>
+/// A processor that reports a stage display message followed by a progress fraction (passing the source through unchanged), used to test message reporting
+/// through the pipeline.
+/// </summary>
+internal sealed class MessageReportingProcessor : FileProcessor
+{
+    public override IReadOnlyList<string> AllowedFileExtensions => [];
+
+    protected override async Task<FileProcessingResult> ProcessAsync(FileProcessingContext context)
+    {
+        if (context.ProgressDisplayMessageCallback is not null)
+            await context.ProgressDisplayMessageCallback("Working").ConfigureAwait(false);
+
+        if (context.ProgressCallback is not null)
+            await context.ProgressCallback(0.5).ConfigureAwait(false);
+
+        var sourceFile = await context.GetSourceAsFileAsync().ConfigureAwait(false);
+        return FileProcessingResult.File(sourceFile, hasChanges: false);
+    }
+}
+
+/// <summary>
 /// Helpers for building common variant pipelines used across the variant alias and retirement tests.
 /// </summary>
 internal static class VariantPipelines

--- a/Tests/FulcrumFS.Videos.Tests/Tests.Helpers.cs
+++ b/Tests/FulcrumFS.Videos.Tests/Tests.Helpers.cs
@@ -10,7 +10,7 @@ using SixLabors.ImageSharp.PixelFormats;
 
 namespace FulcrumFS.Videos;
 
-// This file contains the helper methods and properties used by all of the Tests.*.cs test files, both for VideoProcessor and ThumbnailProcessor.
+// This file contains the helper methods and properties used by all of the Tests.*.cs test files, both for VideoProcessor and VideoFrameExtractionProcessor.
 
 partial class Tests
 {


### PR DESCRIPTION
Changes:
- Send information to indicate when video processor is queueing
- Add new process lifetime levels, so that thumbnails, compatibility checks, and copy operations can finish without being blocked by real renders; we re-use and extend the existing mechanism for this
- Update outdated thumbnail processor references

Will have merge conflict with https://github.com/Singulink/FulcrumFS/pull/37 (resolved)